### PR TITLE
add built out FAQ page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,10 +8,10 @@ import Contacts from "./scenes/contacts";
 import Invoices from "./scenes/invoices";
 import Form from "./scenes/form";
 import Calendar from "./scenes/calendar/calendar";
+import FAQ from "./scenes/faq";
 // import Bar from "./scenes/bar";
 // import Line from "./scenes/line";
 // import Pie from "./scenes/pie";
-// import FAQ from "./scenes/faq";
 // import Geography from "./scenes/geography";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { ColorModeContext, useMode } from "./theme";
@@ -34,10 +34,10 @@ function App() {
               <Route path="/invoices" element={<Invoices />} />
               <Route path="/form" element={<Form />} />
               <Route path="/calendar" element={<Calendar />} />
+              <Route path="/faq" element={<FAQ />} />
               {/* <Route path="/bar" element={<Bar />} /> */}
               {/* <Route path="/pie" element={<Pie />} /> */}
               {/* <Route path="/line" element={<Line />} /> */}
-              {/* <Route path="/faq" element={<FAQ />} /> */}
               {/* <Route path="/geography" element={<Geography />} /> */}
             </Routes>
           </main>

--- a/src/scenes/faq/index.jsx
+++ b/src/scenes/faq/index.jsx
@@ -1,0 +1,126 @@
+import { Box, useTheme } from "@mui/material";
+import Header from "../../components/Header";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import Typography from "@mui/material/Typography";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { tokens } from "../../theme";
+
+const FAQ = () => {
+    const theme = useTheme();
+    const colors = tokens(theme.palette.mode);
+    
+
+    return (
+        <Box m="20px">
+            <Header title="FAQ" subtitle="Frequently Asked Questions Page" />
+
+        <Accordion defaultExpanded>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    An Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    Another Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    A Persistently Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    My Favorite Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    Random Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    Super Random Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    So Many Important Questions
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+
+        <Accordion >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} >
+                <Typography color={colors.greenAccent[500]} variant="h5">
+                    Do you really have another Important Question
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Typography>
+                    The answer is always 42. No matter what you are asking, the answer is 42.
+                </Typography>
+            </AccordionDetails>
+        </Accordion>
+        </Box>
+    )
+}
+
+export default FAQ


### PR DESCRIPTION
# Pull Request

- [x] New feature (adds functionality): built out FAQ page using Accordion, leaving first question as default expanded and the rest closed. 
- [ ] Describe the purpose of this PR(other):
- [x] I have added screenshots, when necessary (see below):
<img width="1685" alt="Screenshot 2023-01-05 at 1 48 50 AM" src="https://user-images.githubusercontent.com/102887963/210728486-6affbe4f-3466-46ed-8733-a710090d031b.png">

# Please describe the tests that you ran to verify your changes.

- [x] I tested my changes in the browser
- [ ] I tested with Cypress

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new bugs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any other comments, questions or concerns?